### PR TITLE
OAuth Device Flow authentication (#2)

### DIFF
--- a/GeckoIssuesApp/ContentView.swift
+++ b/GeckoIssuesApp/ContentView.swift
@@ -10,7 +10,39 @@ struct ContentView: View {
         NavigationSplitView {
             Text("Sidebar")
         } detail: {
-            Text("Welcome to Gecko Issues")
+            VStack(spacing: 16) {
+                switch authStore.state {
+                case .unauthenticated:
+                    Text("Not signed in")
+                        .foregroundStyle(.secondary)
+                    Button("Sign In with GitHub") {
+                        authStore.signIn()
+                    }
+
+                case .authorizing(let userCode, _):
+                    Text("Enter this code on GitHub:")
+                        .foregroundStyle(.secondary)
+                    Text(userCode)
+                        .font(.system(size: 32, weight: .bold, design: .monospaced))
+                        .textSelection(.enabled)
+                    Button("Cancel") {
+                        authStore.cancelSignIn()
+                    }
+
+                case .authenticated(let username):
+                    Text("Signed in as **\(username)**")
+                    Button("Sign Out") {
+                        authStore.signOut()
+                    }
+                }
+
+                if let error = authStore.errorMessage {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            }
+            .padding()
         }
     }
 }

--- a/GeckoIssuesApp/Services/DeviceFlowService.swift
+++ b/GeckoIssuesApp/Services/DeviceFlowService.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Device Flow: app requests a device code -> user enters code at github.com/login/device
 /// -> app polls until authorized -> receives access token.
 struct DeviceFlowService: Sendable {
-    static let clientID = "REPLACE_WITH_CLIENT_ID"
+    static let clientID = "Ov23likOfwNDT0RWfjYZ"
 
     private static let scope = "repo read:org read:project"
     private static let deviceCodeURL = URL(string: "https://github.com/login/device/code")!

--- a/GeckoIssuesApp/Services/DeviceFlowService.swift
+++ b/GeckoIssuesApp/Services/DeviceFlowService.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Handles the GitHub OAuth Device Flow network requests.
+///
+/// Device Flow: app requests a device code -> user enters code at github.com/login/device
+/// -> app polls until authorized -> receives access token.
+struct DeviceFlowService: Sendable {
+    static let clientID = "REPLACE_WITH_CLIENT_ID"
+
+    private static let scope = "repo read:org read:project"
+    private static let deviceCodeURL = URL(string: "https://github.com/login/device/code")!
+    private static let accessTokenURL = URL(string: "https://github.com/login/oauth/access_token")!
+
+    // MARK: - Response Types
+
+    struct DeviceCodeResponse: Sendable {
+        let deviceCode: String
+        let userCode: String
+        let verificationURI: String
+        let expiresIn: Int
+        let interval: Int
+    }
+
+    // MARK: - Device Flow
+
+    /// Step 1: Request a device code from GitHub.
+    func requestDeviceCode() async throws -> DeviceCodeResponse {
+        var request = URLRequest(url: Self.deviceCodeURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let body = "client_id=\(Self.clientID)&scope=\(Self.scope)"
+        request.httpBody = Data(body.utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validateHTTPResponse(response, data: data)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+
+        guard let deviceCode = json["device_code"] as? String,
+              let userCode = json["user_code"] as? String,
+              let verificationURI = json["verification_uri"] as? String else {
+            let errorDesc = json["error_description"] as? String ?? "Unknown error"
+            throw DeviceFlowError.deviceCodeFailed(errorDesc)
+        }
+
+        return DeviceCodeResponse(
+            deviceCode: deviceCode,
+            userCode: userCode,
+            verificationURI: verificationURI,
+            expiresIn: json["expires_in"] as? Int ?? 900,
+            interval: json["interval"] as? Int ?? 5
+        )
+    }
+
+    /// Step 2: Poll for the access token until the user authorizes.
+    ///
+    /// Returns the access token string on success.
+    /// Throws `CancellationError` if the task is cancelled.
+    func pollForAccessToken(deviceCode: String, interval: Int) async throws -> String {
+        var pollInterval = interval
+
+        while !Task.isCancelled {
+            try await Task.sleep(for: .seconds(pollInterval))
+            try Task.checkCancellation()
+
+            var request = URLRequest(url: Self.accessTokenURL)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+            let body = "client_id=\(Self.clientID)&device_code=\(deviceCode)&grant_type=urn:ietf:params:oauth:grant-type:device_code"
+            request.httpBody = Data(body.utf8)
+
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+
+            if let token = json["access_token"] as? String {
+                return token
+            }
+
+            let error = json["error"] as? String ?? ""
+            switch error {
+            case "authorization_pending":
+                continue
+            case "slow_down":
+                pollInterval += 5
+                continue
+            case "expired_token":
+                throw DeviceFlowError.codeExpired
+            case "access_denied":
+                throw DeviceFlowError.accessDenied
+            default:
+                let desc = json["error_description"] as? String ?? error
+                throw DeviceFlowError.pollFailed(desc)
+            }
+        }
+
+        throw CancellationError()
+    }
+
+    // MARK: - Helpers
+
+    private func validateHTTPResponse(_ response: URLResponse, data: Data) throws {
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw DeviceFlowError.httpError(httpResponse.statusCode, body)
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum DeviceFlowError: LocalizedError {
+    case deviceCodeFailed(String)
+    case codeExpired
+    case accessDenied
+    case pollFailed(String)
+    case httpError(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .deviceCodeFailed(let desc):
+            "Failed to start sign-in: \(desc)"
+        case .codeExpired:
+            "The sign-in code expired. Please try again."
+        case .accessDenied:
+            "Access was denied. Please try again."
+        case .pollFailed(let desc):
+            "Sign-in failed: \(desc)"
+        case .httpError(let code, _):
+            "GitHub returned an error (HTTP \(code))."
+        }
+    }
+}

--- a/GeckoIssuesApp/Stores/AuthStore.swift
+++ b/GeckoIssuesApp/Stores/AuthStore.swift
@@ -1,6 +1,131 @@
 import Foundation
+import AppKit
 
-/// Manages OAuth flow, token management, and Keychain storage.
+/// Manages OAuth Device Flow authentication with GitHub.
+///
+/// Orchestrates the sign-in lifecycle: initiating device flow, polling for
+/// authorization, storing the access token, and handling errors. Keychain
+/// persistence is handled separately — this store holds the token in memory.
 @MainActor @Observable
 final class AuthStore {
+
+    // MARK: - Types
+
+    enum AuthState: Equatable {
+        case unauthenticated
+        case authorizing(userCode: String, verificationURL: String)
+        case authenticated(username: String)
+    }
+
+    // MARK: - Properties
+
+    private(set) var state: AuthState = .unauthenticated
+    private(set) var accessToken: String?
+    var errorMessage: String?
+
+    var isAuthenticated: Bool { accessToken != nil }
+
+    // MARK: - Dependencies
+
+    private let deviceFlowService: DeviceFlowService
+
+    // MARK: - Internal
+
+    private var pollTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    init(deviceFlowService: DeviceFlowService = DeviceFlowService()) {
+        self.deviceFlowService = deviceFlowService
+    }
+
+    // MARK: - Sign In
+
+    /// Start the GitHub Device Flow sign-in process.
+    func signIn() {
+        guard case .unauthenticated = state else { return }
+
+        errorMessage = nil
+        pollTask = Task {
+            do {
+                let deviceCode = try await deviceFlowService.requestDeviceCode()
+
+                state = .authorizing(
+                    userCode: deviceCode.userCode,
+                    verificationURL: deviceCode.verificationURI
+                )
+
+                // Open the verification URL in the default browser
+                if let url = URL(string: deviceCode.verificationURI) {
+                    NSWorkspace.shared.open(url)
+                }
+
+                let token = try await deviceFlowService.pollForAccessToken(
+                    deviceCode: deviceCode.deviceCode,
+                    interval: deviceCode.interval
+                )
+
+                accessToken = token
+
+                let username = try await fetchUsername(token: token)
+                state = .authenticated(username: username)
+
+            } catch is CancellationError {
+                state = .unauthenticated
+            } catch let error as URLError where error.code == .notConnectedToInternet
+                || error.code == .timedOut
+                || error.code == .cannotConnectToHost {
+                errorMessage = "You appear to be offline. Please check your internet connection and try again."
+                state = .unauthenticated
+            } catch {
+                errorMessage = error.localizedDescription
+                state = .unauthenticated
+            }
+        }
+    }
+
+    /// Cancel an in-progress sign-in.
+    func cancelSignIn() {
+        pollTask?.cancel()
+        pollTask = nil
+        state = .unauthenticated
+        errorMessage = nil
+    }
+
+    // MARK: - Sign Out
+
+    /// Sign out and clear the access token.
+    func signOut() {
+        pollTask?.cancel()
+        pollTask = nil
+        accessToken = nil
+        state = .unauthenticated
+        errorMessage = nil
+    }
+
+    // MARK: - Helpers
+
+    /// Fetch the authenticated user's login name from the GitHub API.
+    private func fetchUsername(token: String) async throws -> String {
+        var request = URLRequest(url: URL(string: "https://api.github.com/user")!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw DeviceFlowError.httpError(
+                (response as? HTTPURLResponse)?.statusCode ?? 0,
+                String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        guard let login = json["login"] as? String else {
+            throw DeviceFlowError.pollFailed("Failed to fetch GitHub username.")
+        }
+
+        return login
+    }
 }


### PR DESCRIPTION
## Summary
- Add `DeviceFlowService` — Sendable struct handling GitHub Device Flow network requests (device code + polling)
- Implement `AuthStore` with full sign-in lifecycle: unauthenticated → authorizing → authenticated
- Handle all error states: `authorization_pending`, `slow_down`, `expired_token`, `access_denied`, network errors
- Auto-open verification URL in default browser during sign-in
- Token stored in memory; Keychain persistence deferred to #3

**Note:** `DeviceFlowService.clientID` is a placeholder — needs the actual GitHub OAuth App client ID before use.

Closes #2

## Acceptance Criteria
- [x] Initiate Device Flow and receive a user code and verification URL
- [x] Display the user code and open the verification URL in the default browser
- [x] Poll for authorization and receive an access token on success
- [x] Handle `authorization_pending`, `slow_down`, `expired_token`, and `access_denied` responses
- [x] Store the access token in AuthStore on successful authentication
- [x] Handle network errors gracefully during the polling phase

## Test Plan
- [ ] Set a valid client ID, build, and trigger `authStore.signIn()` — verify browser opens with verification URL
- [ ] Enter the user code at github.com/login/device — verify polling completes and state becomes `.authenticated`
- [ ] Cancel during authorizing state — verify state returns to `.unauthenticated`
- [ ] Let the device code expire without authorizing — verify `.codeExpired` error surfaces
- [ ] Disconnect network during polling — verify graceful error message
- [ ] Call `signOut()` — verify token cleared and state is `.unauthenticated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)