### PR TITLE
Settings window with Repositories and GitHub tabs (#22)

### DIFF
--- a/GeckoIssuesApp/GeckoIssuesApp.swift
+++ b/GeckoIssuesApp/GeckoIssuesApp.swift
@@ -24,5 +24,14 @@ struct GeckoIssuesApp: App {
                 database: database
             )
         }
+
+        Settings {
+            SettingsView(
+                appStore: appStore,
+                syncStore: syncStore,
+                authStore: authStore,
+                database: database
+            )
+        }
     }
 }

--- a/GeckoIssuesApp/Stores/SyncStore.swift
+++ b/GeckoIssuesApp/Stores/SyncStore.swift
@@ -244,10 +244,12 @@ final class SyncStore {
                 try ownerAccount.save(db)
             }
 
-            // Upsert repositories; preserve existing tracked flag unless explicitly overridden
+            // Upsert repositories; tracked is additive — newly selected repos
+            // are marked tracked without unmarking previously tracked repos.
             for repo in repos {
-                let shouldTrack = trackedRepoIds.map { $0.contains(repo.databaseId) }
+                let isNewlySelected = trackedRepoIds?.contains(repo.databaseId) == true
                 let existing = try Repository.fetchOne(db, key: repo.databaseId)
+                let wasTracked = existing?.tracked ?? false
                 var repository = Repository(
                     id: repo.databaseId,
                     accountId: repo.owner.databaseId,
@@ -257,7 +259,7 @@ final class SyncStore {
                     description: repo.description,
                     url: repo.url,
                     syncedAt: existing?.syncedAt,
-                    tracked: shouldTrack ?? existing?.tracked ?? false
+                    tracked: isNewlySelected || wasTracked
                 )
                 try repository.save(db)
             }

--- a/GeckoIssuesApp/Views/RepositoryListView.swift
+++ b/GeckoIssuesApp/Views/RepositoryListView.swift
@@ -133,7 +133,7 @@ private struct RepositoryRow: View {
     var repository: Repository
 
     var body: some View {
-        SwiftUI.Label(repository.name, systemImage: repository.isPrivate ? "lock" : "folder")
+        SwiftUI.Label(repository.name, systemImage: repository.isPrivate ? "lock" : "book.closed")
             .accessibilityLabel("\(repository.name)\(repository.isPrivate ? ", private" : "")")
     }
 }

--- a/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
@@ -32,18 +32,10 @@ struct GitHubSettingsTab: View {
                     .font(.system(size: 15, weight: .semibold))
             }
 
-            HStack(spacing: 12) {
-                Button("Disconnect") {
-                    authStore.signOut()
-                }
-                .accessibilityLabel("Disconnect GitHub account")
-
-                Button("Reauthorize") {
-                    authStore.signOut()
-                    authStore.signIn()
-                }
-                .accessibilityLabel("Reauthorize GitHub connection")
+            Button("Reauthorize") {
+                authStore.signOut()
             }
+            .accessibilityLabel("Reauthorize GitHub connection")
 
             Spacer()
         }

--- a/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
@@ -1,105 +1,36 @@
 import SwiftUI
 
 /// Settings tab for managing the GitHub connection.
+///
+/// When connected, shows a green checkmark with Disconnect/Reauthorize actions.
+/// When disconnected or reauthorizing, shows the 3-step auth stepper inline.
 struct GitHubSettingsTab: View {
     var authStore: AuthStore
 
+    @FocusState private var signInButtonFocused: Bool
+
     var body: some View {
-        VStack(spacing: 16) {
-            Spacer()
-
-            switch authStore.state {
-            case .unauthenticated:
-                disconnectedView
-            case .authorizing(let userCode, _):
-                authorizingView(userCode: userCode)
-            case .authenticated(let username):
-                connectedView(username: username)
-            }
-
-            if let error = authStore.errorMessage {
-                Text(error)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
-            }
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    // MARK: - Disconnected
-
-    private var disconnectedView: some View {
-        Group {
-            Image(systemName: "arrow.triangle.branch")
-                .font(.system(size: 40))
-                .foregroundStyle(.secondary)
-
-            Text("Connect to GitHub")
-                .font(.system(size: 15, weight: .semibold))
-
-            Text("Sign in with your GitHub account to sync repositories and issues.")
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 320)
-
-            Button("Sign In with GitHub") {
-                authStore.signIn()
-            }
-            .accessibilityLabel("Sign in with GitHub")
-        }
-    }
-
-    // MARK: - Authorizing
-
-    private func authorizingView(userCode: String) -> some View {
-        Group {
-            ProgressView()
-                .controlSize(.small)
-
-            Text("Enter this code on GitHub")
-                .font(.system(size: 15, weight: .semibold))
-
-            Text(userCode)
-                .font(.system(size: 28, weight: .bold, design: .monospaced))
-                .textSelection(.enabled)
-                .accessibilityLabel("Device code: \(userCode)")
-
-            Text("A browser window has opened to github.com.\nPaste the code above to sign in.")
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 320)
-
-            HStack(spacing: 12) {
-                Button("Copy Code") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(userCode, forType: .string)
-                }
-                .accessibilityLabel("Copy device code to clipboard")
-
-                Button("Cancel") {
-                    authStore.cancelSignIn()
-                }
-                .accessibilityLabel("Cancel sign in")
-            }
+        if authStore.isAuthenticated {
+            connectedView
+        } else {
+            stepperView
         }
     }
 
     // MARK: - Connected
 
-    private func connectedView(username: String) -> some View {
-        Group {
+    private var connectedView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 40))
                 .foregroundStyle(.green)
 
-            Text("Connected as @\(username)")
-                .font(.system(size: 15, weight: .semibold))
+            if case .authenticated(let username) = authStore.state {
+                Text("Connected as @\(username)")
+                    .font(.system(size: 15, weight: .semibold))
+            }
 
             HStack(spacing: 12) {
                 Button("Disconnect") {
@@ -112,6 +43,147 @@ struct GitHubSettingsTab: View {
                     authStore.signIn()
                 }
                 .accessibilityLabel("Reauthorize GitHub connection")
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Stepper
+
+    private var stepperView: some View {
+        VStack(spacing: 0) {
+            Text("Connect to GitHub")
+                .font(.system(size: 15, weight: .semibold))
+                .padding(.top, 32)
+
+            Spacer().frame(height: 32)
+
+            VStack(alignment: .leading, spacing: 0) {
+                AuthStepRow(
+                    number: 1,
+                    title: "Sign in",
+                    state: step1State,
+                    isLast: false
+                ) {
+                    authenticateContent
+                }
+
+                AuthStepRow(
+                    number: 2,
+                    title: "Enter code",
+                    state: step2State,
+                    isLast: false
+                ) {
+                    enterCodeContent
+                }
+
+                AuthStepRow(
+                    number: 3,
+                    title: "Authorize device",
+                    state: step3State,
+                    isLast: true
+                ) {
+                    if case .authenticated(let username) = authStore.state {
+                        Text("Successfully connected as \(username).")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.leading, 40)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Step States
+
+    private var step1State: AuthStepState {
+        switch authStore.state {
+        case .unauthenticated: .active
+        case .authorizing, .authenticated: .completed
+        }
+    }
+
+    private var step2State: AuthStepState {
+        switch authStore.state {
+        case .unauthenticated: .upcoming
+        case .authorizing: .active
+        case .authenticated: .completed
+        }
+    }
+
+    private var step3State: AuthStepState {
+        switch authStore.state {
+        case .unauthenticated: .upcoming
+        case .authorizing: .waiting
+        case .authenticated: .completed
+        }
+    }
+
+    // MARK: - Step Content
+
+    @ViewBuilder
+    private var authenticateContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Open your browser, sign in, then return here to get your code.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Button("Sign in with GitHub") {
+                    authStore.signIn()
+                }
+                .controlSize(.large)
+                .accessibilityLabel("Sign in with GitHub")
+                .disabled(step1State == .completed)
+                .focused($signInButtonFocused)
+
+                if step1State == .completed {
+                    Button {
+                        authStore.signOut()
+                        signInButtonFocused = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.circlepath")
+                            Text("Restart")
+                        }
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("Restart sign-in")
+                }
+            }
+
+            if let error = authStore.errorMessage {
+                Text(error)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var enterCodeContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("After signing in, enter this code when prompted:")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                if case .authorizing(let userCode, _) = authStore.state {
+                    Text(userCode)
+                        .font(.system(size: 22, weight: .bold, design: .monospaced))
+                        .textSelection(.enabled)
+                        .accessibilityLabel("Authorization code: \(userCode)")
+                    CopyButton(value: userCode)
+                } else {
+                    Text("XXXX-XXXX")
+                        .font(.system(size: 22, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
     }

--- a/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// Settings tab for managing the GitHub connection.
+struct GitHubSettingsTab: View {
+    var authStore: AuthStore
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            switch authStore.state {
+            case .unauthenticated:
+                disconnectedView
+            case .authorizing(let userCode, _):
+                authorizingView(userCode: userCode)
+            case .authenticated(let username):
+                connectedView(username: username)
+            }
+
+            if let error = authStore.errorMessage {
+                Text(error)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Disconnected
+
+    private var disconnectedView: some View {
+        Group {
+            Image(systemName: "arrow.triangle.branch")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+
+            Text("Connect to GitHub")
+                .font(.system(size: 15, weight: .semibold))
+
+            Text("Sign in with your GitHub account to sync repositories and issues.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+
+            Button("Sign In with GitHub") {
+                authStore.signIn()
+            }
+            .accessibilityLabel("Sign in with GitHub")
+        }
+    }
+
+    // MARK: - Authorizing
+
+    private func authorizingView(userCode: String) -> some View {
+        Group {
+            ProgressView()
+                .controlSize(.small)
+
+            Text("Enter this code on GitHub")
+                .font(.system(size: 15, weight: .semibold))
+
+            Text(userCode)
+                .font(.system(size: 28, weight: .bold, design: .monospaced))
+                .textSelection(.enabled)
+                .accessibilityLabel("Device code: \(userCode)")
+
+            Text("A browser window has opened to github.com.\nPaste the code above to sign in.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+
+            HStack(spacing: 12) {
+                Button("Copy Code") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(userCode, forType: .string)
+                }
+                .accessibilityLabel("Copy device code to clipboard")
+
+                Button("Cancel") {
+                    authStore.cancelSignIn()
+                }
+                .accessibilityLabel("Cancel sign in")
+            }
+        }
+    }
+
+    // MARK: - Connected
+
+    private func connectedView(username: String) -> some View {
+        Group {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(.green)
+
+            Text("Connected as @\(username)")
+                .font(.system(size: 15, weight: .semibold))
+
+            Button("Sign Out") {
+                authStore.signOut()
+            }
+            .accessibilityLabel("Sign out of GitHub")
+        }
+    }
+}

--- a/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
@@ -101,10 +101,18 @@ struct GitHubSettingsTab: View {
             Text("Connected as @\(username)")
                 .font(.system(size: 15, weight: .semibold))
 
-            Button("Sign Out") {
-                authStore.signOut()
+            HStack(spacing: 12) {
+                Button("Disconnect") {
+                    authStore.signOut()
+                }
+                .accessibilityLabel("Disconnect GitHub account")
+
+                Button("Reauthorize") {
+                    authStore.signOut()
+                    authStore.signIn()
+                }
+                .accessibilityLabel("Reauthorize GitHub connection")
             }
-            .accessibilityLabel("Sign out of GitHub")
         }
     }
 }

--- a/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/GitHubSettingsTab.swift
@@ -32,10 +32,10 @@ struct GitHubSettingsTab: View {
                     .font(.system(size: 15, weight: .semibold))
             }
 
-            Button("Reauthorize") {
+            Button("Reconnect") {
                 authStore.signOut()
             }
-            .accessibilityLabel("Reauthorize GitHub connection")
+            .accessibilityLabel("Reconnect GitHub account")
 
             Spacer()
         }

--- a/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
@@ -67,7 +67,7 @@ struct RepositoriesSettingsTab: View {
                     Section {
                         ForEach(group.repos, id: \.id) { repo in
                             HStack(spacing: 8) {
-                                Image(systemName: repo.isPrivate ? "lock" : "folder")
+                                Image(systemName: repo.isPrivate ? "lock" : "book.closed")
                                     .font(.system(size: 13))
                                     .foregroundStyle(.secondary)
                                     .frame(width: 16)
@@ -82,12 +82,13 @@ struct RepositoriesSettingsTab: View {
                             AccountAvatar(
                                 login: group.login,
                                 avatarURL: group.avatarURL,
-                                size: 16
+                                size: 20
                             )
-                            Text(group.login.uppercased())
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(.secondary)
+                            Text(group.login)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(.primary)
                         }
+                        .padding(.bottom, 4)
                     }
                 }
             }
@@ -129,7 +130,7 @@ struct RepositoriesSettingsTab: View {
     private var detailPane: some View {
         if let repo = selectedRepo {
             VStack(spacing: 8) {
-                Image(systemName: repo.isPrivate ? "lock.shield" : "folder")
+                Image(systemName: repo.isPrivate ? "lock" : "book.closed")
                     .font(.system(size: 32))
                     .foregroundStyle(.secondary)
                 Text(repo.nameWithOwner)

--- a/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
@@ -39,7 +39,8 @@ struct RepositoriesSettingsTab: View {
                 syncStore: syncStore,
                 appStore: appStore,
                 database: database,
-                startStep: .selectRepos
+                startStep: .selectRepos,
+                alreadyTrackedRepoIds: trackedRepoIds
             )
         }
         .alert(
@@ -150,6 +151,10 @@ struct RepositoriesSettingsTab: View {
     private var selectedRepo: Repository? {
         guard let id = selectedRepoId else { return nil }
         return accountGroups.flatMap(\.repos).first { $0.id == id }
+    }
+
+    private var trackedRepoIds: Set<Int64> {
+        Set(accountGroups.flatMap(\.repos).map(\.id))
     }
 
     // MARK: - Data Loading

--- a/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+import GRDB
+
+/// Settings tab for managing tracked repositories — list on the left, detail pane on the right.
+struct RepositoriesSettingsTab: View {
+    var appStore: AppStore
+    var syncStore: SyncStore
+    var authStore: AuthStore
+    var database: AppDatabase
+
+    @State private var accountGroups: [SettingsAccountGroup] = []
+    @State private var selectedRepoId: Int64?
+    @State private var showDeleteConfirmation = false
+    @State private var showAddReposWizard = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            repoList
+                .frame(width: 200)
+
+            Divider()
+
+            detailPane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task {
+            await loadTrackedRepos()
+        }
+        .onChange(of: syncStore.state) {
+            if case .completed = syncStore.state {
+                Task { await loadTrackedRepos() }
+            }
+        }
+        .sheet(isPresented: $showAddReposWizard) {
+            Task { await loadTrackedRepos() }
+        } content: {
+            OnboardingWizardSheet(
+                authStore: authStore,
+                syncStore: syncStore,
+                appStore: appStore,
+                database: database,
+                startStep: .selectRepos
+            )
+        }
+        .alert(
+            "Remove Repository",
+            isPresented: $showDeleteConfirmation
+        ) {
+            Button("Remove", role: .destructive) {
+                Task { await deleteSelected() }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            if let repo = selectedRepo {
+                Text("This will remove \(repo.nameWithOwner) and all its synced data.")
+            }
+        }
+    }
+
+    // MARK: - Repo List
+
+    private var repoList: some View {
+        VStack(spacing: 0) {
+            List(selection: $selectedRepoId) {
+                ForEach(accountGroups) { group in
+                    Section {
+                        ForEach(group.repos, id: \.id) { repo in
+                            HStack(spacing: 8) {
+                                Image(systemName: repo.isPrivate ? "lock" : "folder")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 16)
+                                Text(repo.name)
+                                    .lineLimit(1)
+                            }
+                            .tag(repo.id)
+                            .accessibilityLabel("\(repo.name)\(repo.isPrivate ? ", private" : "")")
+                        }
+                    } header: {
+                        HStack(spacing: 6) {
+                            AccountAvatar(
+                                login: group.login,
+                                avatarURL: group.avatarURL,
+                                size: 16
+                            )
+                            Text(group.login.uppercased())
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+
+            HStack(spacing: 4) {
+                Spacer()
+                Divider()
+                    .frame(height: 24)
+                Button {
+                    showAddReposWizard = true
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.borderless)
+                .disabled(!authStore.isAuthenticated)
+                .accessibilityLabel("Add repositories")
+                Divider()
+                    .frame(height: 24)
+                Button {
+                    showDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "minus")
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.borderless)
+                .disabled(selectedRepoId == nil)
+                .accessibilityLabel("Remove repository")
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Detail Pane
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if let repo = selectedRepo {
+            VStack(spacing: 8) {
+                Image(systemName: repo.isPrivate ? "lock.shield" : "folder")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.secondary)
+                Text(repo.nameWithOwner)
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Repository settings coming soon.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            Text("No Repository Selected")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var selectedRepo: Repository? {
+        guard let id = selectedRepoId else { return nil }
+        return accountGroups.flatMap(\.repos).first { $0.id == id }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadTrackedRepos() async {
+        do {
+            let groups = try await database.dbQueue.read { db in
+                let accounts = try Account
+                    .joining(required: Account.repositories.filter(Column("tracked") == true))
+                    .distinct()
+                    .order(
+                        Column("type").desc,
+                        Column("login").collating(.localizedCaseInsensitiveCompare)
+                    )
+                    .fetchAll(db)
+
+                return try accounts.map { account in
+                    let repos = try Repository
+                        .filter(Column("accountId") == account.id)
+                        .filter(Column("tracked") == true)
+                        .order(Column("name").collating(.localizedCaseInsensitiveCompare))
+                        .fetchAll(db)
+                    return SettingsAccountGroup(
+                        id: account.id,
+                        login: account.login,
+                        avatarURL: account.avatarURL,
+                        repos: repos
+                    )
+                }
+            }
+            accountGroups = groups
+
+            // Auto-select first repo if current selection is gone
+            if selectedRepoId == nil || !groups.flatMap(\.repos).contains(where: { $0.id == selectedRepoId }) {
+                selectedRepoId = groups.first?.repos.first?.id
+            }
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    // MARK: - Delete
+
+    private func deleteSelected() async {
+        guard let repoId = selectedRepoId else { return }
+        do {
+            try await database.dbQueue.write { db in
+                // Untrack the repo and clear its synced data
+                try db.execute(
+                    sql: "UPDATE repositories SET tracked = 0, syncedAt = NULL WHERE id = ?",
+                    arguments: [repoId]
+                )
+                // Delete issues (cascade will handle labels, comments, assignees)
+                try Issue.filter(Column("repositoryId") == repoId).deleteAll(db)
+                try Milestone.filter(Column("repositoryId") == repoId).deleteAll(db)
+                try Label.filter(Column("repositoryId") == repoId).deleteAll(db)
+            }
+
+            // Remove accounts that no longer have tracked repos
+            try await database.dbQueue.write { db in
+                try db.execute(sql: """
+                    DELETE FROM accounts
+                    WHERE id NOT IN (
+                        SELECT DISTINCT accountId FROM repositories WHERE tracked = 1
+                    )
+                """)
+            }
+
+            selectedRepoId = nil
+            await loadTrackedRepos()
+            await appStore.loadAccounts(from: database)
+        } catch {
+            // Non-fatal
+        }
+    }
+}
+
+// MARK: - Settings Account Group
+
+struct SettingsAccountGroup: Identifiable {
+    let id: Int64
+    let login: String
+    let avatarURL: String?
+    let repos: [Repository]
+}

--- a/GeckoIssuesApp/Views/Settings/SettingsView.swift
+++ b/GeckoIssuesApp/Views/Settings/SettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Settings tab identifiers.
+enum SettingsTab: String {
+    case repositories
+    case github
+}
+
+/// Root view for the Settings window, containing tabbed panes.
+struct SettingsView: View {
+    var appStore: AppStore
+    var syncStore: SyncStore
+    var authStore: AuthStore
+    var database: AppDatabase
+
+    @AppStorage("SettingsSelectedTab") private var selectedTab = SettingsTab.repositories.rawValue
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            RepositoriesSettingsTab(
+                appStore: appStore,
+                syncStore: syncStore,
+                authStore: authStore,
+                database: database
+            )
+            .tabItem {
+                SwiftUI.Label("Repositories", systemImage: "folder")
+            }
+            .tag(SettingsTab.repositories.rawValue)
+
+            GitHubSettingsTab(authStore: authStore)
+                .tabItem {
+                    SwiftUI.Label("GitHub", systemImage: "cat")
+                }
+                .tag(SettingsTab.github.rawValue)
+        }
+        .frame(width: 740, height: 520)
+    }
+}

--- a/GeckoIssuesApp/Views/Settings/SettingsView.swift
+++ b/GeckoIssuesApp/Views/Settings/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
 
             GitHubSettingsTab(authStore: authStore)
                 .tabItem {
-                    SwiftUI.Label("GitHub", systemImage: "cat")
+                    SwiftUI.Label("GitHub", systemImage: "arrow.triangle.branch")
                 }
                 .tag(SettingsTab.github.rawValue)
         }

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
@@ -176,7 +176,7 @@ enum AuthStepState {
     case completed  // green checkmark
 }
 
-private struct AuthStepRow<Content: View>: View {
+struct AuthStepRow<Content: View>: View {
     let number: Int
     let title: String
     let state: AuthStepState

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/OnboardingWizardSheet.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/OnboardingWizardSheet.swift
@@ -29,6 +29,7 @@ struct OnboardingWizardSheet: View {
     var appStore: AppStore
     var database: AppDatabase
     var startStep: WizardStep = .connectGitHub
+    var alreadyTrackedRepoIds: Set<Int64> = []
 
     @Environment(\.dismiss) private var dismiss
 
@@ -66,6 +67,7 @@ struct OnboardingWizardSheet: View {
                     authStore: authStore,
                     syncService: syncService,
                     selectedRepoIds: $selectedRepoIds,
+                    alreadyTrackedRepoIds: alreadyTrackedRepoIds,
                     onBack: {
                         if startStep == .selectRepos {
                             dismiss()

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/OnboardingWizardSheet.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/OnboardingWizardSheet.swift
@@ -20,17 +20,21 @@ struct RepoOption: Identifiable, Equatable {
 
 /// 3-step onboarding wizard shown on first launch to guide the user
 /// from a cold start to a live-syncing app.
+///
+/// Pass `startStep` to skip earlier steps (e.g. when launched from Settings
+/// after the user is already authenticated).
 struct OnboardingWizardSheet: View {
     var authStore: AuthStore
     var syncStore: SyncStore
     var appStore: AppStore
     var database: AppDatabase
+    var startStep: WizardStep = .connectGitHub
 
     @Environment(\.dismiss) private var dismiss
 
     private let syncService = GitHubSyncService()
 
-    @State private var step: WizardStep = .connectGitHub
+    @State private var step: WizardStep?
     @State private var selectedRepoIds: Set<Int64> = []
 
     // MARK: - Step Enum
@@ -43,9 +47,13 @@ struct OnboardingWizardSheet: View {
 
     // MARK: - Body
 
+    private var currentStep: WizardStep {
+        step ?? startStep
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            switch step {
+            switch currentStep {
             case .connectGitHub:
                 ConnectGitHubStepView(
                     authStore: authStore,
@@ -58,7 +66,13 @@ struct OnboardingWizardSheet: View {
                     authStore: authStore,
                     syncService: syncService,
                     selectedRepoIds: $selectedRepoIds,
-                    onBack: { step = .connectGitHub },
+                    onBack: {
+                        if startStep == .selectRepos {
+                            dismiss()
+                        } else {
+                            step = .connectGitHub
+                        }
+                    },
                     onContinue: { step = .syncing }
                 )
 

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/SelectReposStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/SelectReposStepView.swift
@@ -17,6 +17,7 @@ struct SelectReposStepView: View {
     var authStore: AuthStore
     var syncService: any SyncServiceProtocol
     @Binding var selectedRepoIds: Set<Int64>
+    var alreadyTrackedRepoIds: Set<Int64> = []
     var onBack: () -> Void
     var onContinue: () -> Void
 
@@ -115,7 +116,8 @@ struct SelectReposStepView: View {
                             ForEach(group.repos) { repo in
                                 RepoRow(
                                     repo: repo,
-                                    isSelected: selectedRepoIds.contains(repo.id),
+                                    isSelected: selectedRepoIds.contains(repo.id) || alreadyTrackedRepoIds.contains(repo.id),
+                                    isDisabled: alreadyTrackedRepoIds.contains(repo.id),
                                     onToggle: { toggleRepo(repo.id) }
                                 )
                             }
@@ -262,6 +264,7 @@ private struct AccountHeader: View {
 private struct RepoRow: View {
     var repo: RepoOption
     var isSelected: Bool
+    var isDisabled: Bool = false
     var onToggle: () -> Void
 
     var body: some View {
@@ -280,10 +283,12 @@ private struct RepoRow: View {
                 Spacer()
             }
             .contentShape(Rectangle())
+            .opacity(isDisabled ? 0.4 : 1.0)
         }
         .buttonStyle(.plain)
+        .disabled(isDisabled)
         .padding(.vertical, 2)
-        .accessibilityLabel("\(repo.name)\(repo.isPrivate ? ", private" : "")\(isSelected ? ", selected" : ", not selected")")
+        .accessibilityLabel("\(repo.name)\(repo.isPrivate ? ", private" : "")\(isDisabled ? ", already added" : isSelected ? ", selected" : ", not selected")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/SelectReposStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/SelectReposStepView.swift
@@ -274,7 +274,7 @@ private struct RepoRow: View {
                     .font(.system(size: 15))
                     .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                     .frame(width: 18)
-                Image(systemName: repo.isPrivate ? "lock" : "folder")
+                Image(systemName: repo.isPrivate ? "lock" : "book.closed")
                     .font(.system(size: 13))
                     .foregroundStyle(.secondary)
                     .frame(width: 16)


### PR DESCRIPTION
## Summary
- Add macOS Settings window (`Cmd+,`) with icon tab bar
- **Repositories tab**: master-detail layout with tracked repos grouped by org section headers, +/− buttons at bottom
  - "+" launches the onboarding wizard at the repo selection step to add new repos
  - "−" removes the selected repo, deletes its synced data, and cleans up orphaned accounts
- **GitHub tab**: shows connection status with sign in/sign out controls (mirrors the first onboarding step)
- `OnboardingWizardSheet` now accepts an optional `startStep` parameter to skip earlier steps

Closes #22

## Acceptance Criteria
- [x] Settings window opens via `Cmd+,` / Gecko → Settings
- [x] Icon tab bar across the top with icons centered above tab labels
- [x] Tabs: Repositories and GitHub
- [x] Repositories tab has master-detail layout: list on left, detail on right
- [x] Repos listed in a flat list with organization section headers
- [x] +/− buttons at the bottom of the list (matching ContextStore's Spaces pattern)
- [x] "+" button launches the onboarding wizard at the Select Repos step
- [x] "−" button removes the selected repo after a confirmation alert; deletes its data from local store
- [x] Right pane shows a placeholder for per-repo settings
- [x] After wizard completes, new repos appear in the list immediately
- [x] Settings window uses SwiftUI `Settings { }` scene with `TabView` for tab navigation

## Test Plan
- [ ] Open Settings via `Cmd+,` — window appears with Repositories tab selected
- [ ] Click GitHub tab — shows connection status or sign-in prompt
- [ ] Click "+" in Repositories tab — onboarding wizard opens at repo selection step
- [ ] Select repos in wizard and complete sync — new repos appear in settings list
- [ ] Select a repo and click "−" — confirmation alert appears, repo removed after confirm
- [ ] Verify removed repo no longer appears in main window sidebar
- [ ] Sign out in GitHub tab, verify sign-in UI appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)