### PR TITLE
Selective sync — only sync tracked repos (#23)

### DIFF
--- a/GeckoIssuesApp/Stores/AppStore.swift
+++ b/GeckoIssuesApp/Stores/AppStore.swift
@@ -8,6 +8,12 @@ final class AppStore {
     var selectedAccount: Account?
     var selectedRepository: Repository?
     var selectedIssue: Issue?
+    private(set) var repositoryChangeCount = 0
+
+    /// Signal that the tracked repository set has changed so views can reload.
+    func repositoriesDidChange() {
+        repositoryChangeCount += 1
+    }
 
     /// Load accounts that own at least one tracked repository, sorted with user accounts first, then orgs.
     func loadAccounts(from database: AppDatabase) async {

--- a/GeckoIssuesApp/Stores/AppStore.swift
+++ b/GeckoIssuesApp/Stores/AppStore.swift
@@ -23,8 +23,8 @@ final class AppStore {
                     )
                     .fetchAll(db)
             }
-            // Auto-select first account if none selected
-            if selectedAccount == nil {
+            // Auto-select first account if none selected or current was removed
+            if selectedAccount == nil || !accounts.contains(where: { $0.id == selectedAccount?.id }) {
                 selectedAccount = accounts.first
             }
         } catch {

--- a/GeckoIssuesApp/Stores/SyncStore.swift
+++ b/GeckoIssuesApp/Stores/SyncStore.swift
@@ -61,29 +61,61 @@ final class SyncStore {
 
     // MARK: - Sync
 
-    /// Start a full sync of all repositories and issues from GitHub.
+    /// Refresh all tracked repos by re-fetching their issues from GitHub.
+    ///
+    /// Reads the set of tracked repo IDs from the local database and only
+    /// fetches issues for those repos. Does not discover new repos — use
+    /// `startSyncForRepos(repoIds:token:)` for that.
     func startFullSync(token: String) {
-        startSync(token: token, repoIds: nil)
+        if case .syncing = state { return }
+
+        errorMessage = nil
+        syncTask = Task {
+            do {
+                let trackedRepos = try await database.dbQueue.read { db in
+                    try Repository
+                        .filter(Column("tracked") == true)
+                        .fetchAll(db)
+                }
+
+                guard !trackedRepos.isEmpty else {
+                    logger.info("No tracked repos to sync")
+                    state = .completed(Date())
+                    return
+                }
+
+                logger.info("Starting refresh sync for \(trackedRepos.count) tracked repos")
+
+                let repoEntries = trackedRepos.map {
+                    (id: $0.id, nameWithOwner: $0.nameWithOwner)
+                }
+                try await syncIssues(for: repoEntries, token: token)
+
+                state = .completed(Date())
+                logger.info("Sync completed")
+            } catch is CancellationError {
+                state = .idle
+                logger.info("Sync cancelled")
+            } catch {
+                if Task.isCancelled {
+                    state = .idle
+                    logger.info("Sync cancelled")
+                } else {
+                    let message = error.localizedDescription
+                    state = .error(message)
+                    errorMessage = message
+                    logger.error("Sync failed: \(message)")
+                }
+            }
+        }
     }
 
-    /// Start a sync limited to the specified repository IDs.
+    /// Discover repos from GitHub and sync issues for the specified repo IDs.
     ///
     /// All repos and org memberships are persisted to the DB, but issues are only
-    /// fetched for repos in `repoIds`. The sidebar filters to repos with `syncedAt != nil`,
-    /// so only the selected repos appear there.
+    /// fetched for repos in `repoIds`. Used during onboarding and when adding
+    /// repos via Settings.
     func startSyncForRepos(repoIds: Set<Int64>, token: String) {
-        startSync(token: token, repoIds: repoIds)
-    }
-
-    /// Cancel an in-progress sync.
-    func cancelSync() {
-        syncTask?.cancel()
-        syncTask = nil
-    }
-
-    // MARK: - Private Sync
-
-    private func startSync(token: String, repoIds: Set<Int64>?) {
         if case .syncing = state { return }
 
         errorMessage = nil
@@ -95,8 +127,7 @@ final class SyncStore {
                     repositoriesSynced: 0,
                     repositoriesTotal: 0
                 ))
-                let label = repoIds == nil ? "full" : "selective (\(repoIds!.count) repos)"
-                logger.info("Starting \(label) sync")
+                logger.info("Starting discovery sync (\(repoIds.count) repos)")
 
                 let viewerData = try await syncService.fetchViewerWithOrganizations(token: token)
                 let viewer = viewerData.viewer
@@ -148,35 +179,15 @@ final class SyncStore {
                 // Step 3: Save accounts + all repos; mark selected repos as tracked
                 try await persistAccountsAndRepos(viewer: viewer, orgAccounts: orgAccounts, repos: repos, trackedRepoIds: repoIds)
 
-                // Step 4: Fetch and persist issues — filtered to selected repos if provided
-                let reposToSync = repoIds.map { ids in repos.filter { ids.contains($0.databaseId) } } ?? repos
-                for (index, repo) in reposToSync.enumerated() {
-                    try Task.checkCancellation()
-
-                    state = .syncing(SyncProgress(
-                        phase: .syncingRepository(repo.nameWithOwner),
-                        repositoriesSynced: index,
-                        repositoriesTotal: reposToSync.count
-                    ))
-
-                    let parts = repo.nameWithOwner.split(separator: "/", maxSplits: 1)
-                    let owner = String(parts[0])
-                    let name = String(parts[1])
-
-                    let issues = try await syncService.fetchIssues(
-                        owner: owner,
-                        name: name,
-                        token: token
-                    )
-                    logger.info("Fetched \(issues.count) issues for \(repo.nameWithOwner)")
-
-                    try await persistIssues(issues, repositoryId: repo.databaseId)
+                // Step 4: Fetch and persist issues for selected repos only
+                let reposToSync = repos.filter { repoIds.contains($0.databaseId) }
+                let repoEntries = reposToSync.map {
+                    (id: $0.databaseId, nameWithOwner: $0.nameWithOwner)
                 }
+                try await syncIssues(for: repoEntries, token: token)
 
-                let completedAt = Date()
-                state = .completed(completedAt)
+                state = .completed(Date())
                 logger.info("Sync completed")
-
             } catch is CancellationError {
                 state = .idle
                 logger.info("Sync cancelled")
@@ -192,6 +203,43 @@ final class SyncStore {
                     logger.error("Sync failed: \(message)")
                 }
             }
+        }
+    }
+
+    /// Cancel an in-progress sync.
+    func cancelSync() {
+        syncTask?.cancel()
+        syncTask = nil
+    }
+
+    // MARK: - Private Sync
+
+    /// Fetch and persist issues for the given repos, updating sync progress.
+    private func syncIssues(
+        for repos: [(id: Int64, nameWithOwner: String)],
+        token: String
+    ) async throws {
+        for (index, repo) in repos.enumerated() {
+            try Task.checkCancellation()
+
+            state = .syncing(SyncProgress(
+                phase: .syncingRepository(repo.nameWithOwner),
+                repositoriesSynced: index,
+                repositoriesTotal: repos.count
+            ))
+
+            let parts = repo.nameWithOwner.split(separator: "/", maxSplits: 1)
+            let owner = String(parts[0])
+            let name = String(parts[1])
+
+            let issues = try await syncService.fetchIssues(
+                owner: owner,
+                name: name,
+                token: token
+            )
+            logger.info("Fetched \(issues.count) issues for \(repo.nameWithOwner)")
+
+            try await persistIssues(issues, repositoryId: repo.id)
         }
     }
 

--- a/GeckoIssuesApp/Stores/SyncStore.swift
+++ b/GeckoIssuesApp/Stores/SyncStore.swift
@@ -147,11 +147,13 @@ final class SyncStore {
 
                 // Step 2b: Discover org accounts and fetch their repos directly
                 var seenRepoIds = Set(repos.map(\.databaseId))
-                let orgLogins = Set(
+                let orgLoginsFromRepos = Set(
                     repos
                         .filter { $0.owner.typeName == "Organization" }
                         .map(\.owner.login)
                 )
+                let orgLoginsFromMemberships = Set(orgAccounts.map(\.login))
+                let orgLogins = orgLoginsFromRepos.union(orgLoginsFromMemberships)
                 for orgLogin in orgLogins {
                     try Task.checkCancellation()
                     do {

--- a/GeckoIssuesApp/Views/RepositoryListView.swift
+++ b/GeckoIssuesApp/Views/RepositoryListView.swift
@@ -80,6 +80,9 @@ struct RepositoryListView: View {
         .onChange(of: appStore.selectedAccount?.id) {
             Task { await loadRepositories() }
         }
+        .onChange(of: appStore.repositoryChangeCount) {
+            Task { await loadRepositories() }
+        }
     }
 
     // MARK: - Filtering

--- a/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
@@ -233,6 +233,7 @@ struct RepositoriesSettingsTab: View {
             selectedRepoId = nil
             await loadTrackedRepos()
             await appStore.loadAccounts(from: database)
+            appStore.repositoriesDidChange()
         } catch {
             // Non-fatal
         }

--- a/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
+++ b/GeckoIssuesApp/Views/Settings/RepositoriesSettingsTab.swift
@@ -224,6 +224,12 @@ struct RepositoriesSettingsTab: View {
                 """)
             }
 
+            // Clear app selections if the deleted repo was active
+            if appStore.selectedRepository?.id == repoId {
+                appStore.selectedIssue = nil
+                appStore.selectedRepository = nil
+            }
+
             selectedRepoId = nil
             await loadTrackedRepos()
             await appStore.loadAccounts(from: database)

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
@@ -43,8 +43,7 @@ struct SyncingStepView: View {
             .padding(.bottom, 24)
         }
         .task {
-            guard case .idle = syncStore.state,
-                  let token = authStore.accessToken else { return }
+            guard let token = authStore.accessToken else { return }
             syncStore.startSyncForRepos(repoIds: selectedRepoIds, token: token)
         }
     }

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
@@ -102,7 +102,7 @@ struct SyncingStepView: View {
                     .multilineTextAlignment(.center)
                 Button("Retry") {
                     guard let token = authStore.accessToken else { return }
-                    syncStore.startFullSync(token: token)
+                    syncStore.startSyncForRepos(repoIds: selectedRepoIds, token: token)
                 }
                 .controlSize(.large)
                 .accessibilityLabel("Retry sync")

--- a/GeckoIssuesTests/SyncStoreTests.swift
+++ b/GeckoIssuesTests/SyncStoreTests.swift
@@ -144,9 +144,9 @@ private func makeCommentData(id: Int64 = 600) -> GitHubSyncService.CommentData {
 @Suite("SyncStore")
 struct SyncStoreTests {
 
-    @Test("Full sync persists account, repos, issues, labels, milestones, assignees, comments")
+    @Test("Discovery sync persists account, repos, issues, labels, milestones, assignees, comments")
     @MainActor
-    func fullSyncPersistsAllData() async throws {
+    func discoverySyncPersistsAllData() async throws {
         let db = try AppDatabase.inMemory()
         let milestone = makeMilestoneData()
         let label = makeLabelData()
@@ -166,7 +166,7 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "test-token")
+        store.startSyncForRepos(repoIds: [100], token: "test-token")
 
         // Wait for sync to complete
         while true {
@@ -248,7 +248,7 @@ struct SyncStoreTests {
         let store = SyncStore(database: db, syncService: mock)
         #expect(store.state == .idle)
 
-        store.startFullSync(token: "test-token")
+        store.startSyncForRepos(repoIds: [100], token: "test-token")
 
         // Wait for completion
         while true {
@@ -271,7 +271,7 @@ struct SyncStoreTests {
         let failing = FailingSyncService(error: GraphQLClientError.unauthorized)
         let store = SyncStore(database: db, syncService: failing)
 
-        store.startFullSync(token: "bad-token")
+        store.startSyncForRepos(repoIds: [100], token: "bad-token")
 
         // Wait for error state
         while true {
@@ -309,7 +309,7 @@ struct SyncStoreTests {
 
         // First sync
         let store1 = SyncStore(database: db, syncService: mock1)
-        store1.startFullSync(token: "token")
+        store1.startSyncForRepos(repoIds: [100], token: "token")
         while true {
             try await Task.sleep(for: .milliseconds(50))
             if case .completed = store1.state { break }
@@ -340,6 +340,7 @@ struct SyncStoreTests {
             issuesByRepo: ["octocat/hello-world": [issue2]]
         )
 
+        // Second sync uses startFullSync — repo is already tracked from first sync
         let store2 = SyncStore(database: db, syncService: mock2)
         store2.startFullSync(token: "token")
         while true {
@@ -371,7 +372,7 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [100], token: "token")
 
         while true {
             try await Task.sleep(for: .milliseconds(50))
@@ -410,7 +411,7 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [100, 101], token: "token")
 
         while true {
             try await Task.sleep(for: .milliseconds(50))
@@ -443,10 +444,10 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [], token: "token")
 
         // Immediately try starting another sync — should be ignored
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [], token: "token")
 
         while true {
             try await Task.sleep(for: .milliseconds(50))
@@ -474,7 +475,7 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [100], token: "token")
 
         while true {
             try await Task.sleep(for: .milliseconds(50))
@@ -517,7 +518,7 @@ struct SyncStoreTests {
         )
 
         let store = SyncStore(database: db, syncService: mock)
-        store.startFullSync(token: "token")
+        store.startSyncForRepos(repoIds: [100, 101, 102], token: "token")
 
         while true {
             try await Task.sleep(for: .milliseconds(50))
@@ -533,6 +534,92 @@ struct SyncStoreTests {
 
         let names = Set(repos.map(\.name))
         #expect(names == ["repo-a", "repo-b", "repo-c"])
+    }
+    @Test("Full sync only syncs tracked repos")
+    @MainActor
+    func fullSyncOnlySyncsTrackedRepos() async throws {
+        let db = try AppDatabase.inMemory()
+        let owner = makeOwnerData()
+        let repo1 = makeRepoData(id: 100, name: "tracked-repo", owner: owner)
+        let repo2 = makeRepoData(id: 101, name: "untracked-repo", owner: owner)
+
+        let issue1 = makeIssueData(id: 400, number: 1)
+        let issue2 = makeIssueData(id: 401, number: 2)
+
+        // First: discovery sync to set up repos — only track repo1
+        let discoveryMock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo1, repo2],
+            issuesByRepo: [
+                "octocat/tracked-repo": [issue1],
+                "octocat/untracked-repo": [issue2]
+            ]
+        )
+        let store1 = SyncStore(database: db, syncService: discoveryMock)
+        store1.startSyncForRepos(repoIds: [100], token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store1.state { break }
+            if case .error(let msg) = store1.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Only tracked repo should have issues
+        let issuesBefore = try await db.dbQueue.read { db in
+            try GeckoIssues.Issue.fetchAll(db)
+        }
+        #expect(issuesBefore.count == 1)
+        #expect(issuesBefore[0].repositoryId == 100)
+
+        // Now do a full sync (refresh) — should still only sync tracked repo
+        let issue3 = makeIssueData(id: 402, number: 3)
+        let refreshMock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo1, repo2],
+            issuesByRepo: [
+                "octocat/tracked-repo": [issue1, issue3],
+                "octocat/untracked-repo": [issue2]
+            ]
+        )
+        let store2 = SyncStore(database: db, syncService: refreshMock)
+        store2.startFullSync(token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store2.state { break }
+            if case .error(let msg) = store2.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Should have 2 issues (both from tracked repo), none from untracked
+        let issuesAfter = try await db.dbQueue.read { db in
+            try GeckoIssues.Issue.fetchAll(db)
+        }
+        #expect(issuesAfter.count == 2)
+        #expect(issuesAfter.allSatisfy { $0.repositoryId == 100 })
+    }
+
+    @Test("Full sync with no tracked repos completes immediately")
+    @MainActor
+    func fullSyncNoTrackedRepos() async throws {
+        let db = try AppDatabase.inMemory()
+        let mock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [],
+            issuesByRepo: [:]
+        )
+
+        let store = SyncStore(database: db, syncService: mock)
+        store.startFullSync(token: "token")
+
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store.state { break }
+            if case .error(let msg) = store.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Should complete with no issues or repos
+        let repos = try await db.dbQueue.read { db in
+            try Repository.fetchAll(db)
+        }
+        #expect(repos.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary
- `startFullSync` now reads tracked repo IDs from the local database and only fetches issues for those repos, skipping repo discovery entirely
- `startSyncForRepos` (used by onboarding/Settings) retains full discovery behavior — fetches all repos from GitHub, persists accounts/repos, syncs issues for selected repos only
- Extracted shared `syncIssues(for:token:)` helper to avoid duplicating the issue-fetch loop
- Fixed retry button in SyncingStepView to use `startSyncForRepos` (was incorrectly calling `startFullSync`)
- Fixed wizard not syncing when reopened from Settings (stale `.completed` state)
- Fixed org repo discovery using org memberships (not just repo owners)
- Fixed sidebar and account picker not updating when a tracked repo is deleted

Closes #23

## Acceptance Criteria
- [x] `SyncStore` reads the set of tracked repo IDs before each sync and only fetches issues for those repos
- [x] Repos that are not tracked are not fetched or stored
- [x] Adding a repo via Settings (or re-running the wizard) immediately includes it in the next sync
- [x] Removing a repo via Settings removes it from the tracked set; its local data is deleted
- [x] Tracked repo selection is persisted across app launches (stored in the local database)

## Test Plan
- [x] Launch app with existing tracked repos — verify only tracked repos sync
- [x] Add a new repo via Settings wizard — verify it syncs immediately
- [x] Remove a repo via Settings — verify its issues are deleted and it no longer syncs
- [x] Trigger a full sync refresh — verify only tracked repos are fetched
- [x] With no tracked repos, verify sync completes immediately without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)