### PR TITLE
Incremental sync using updatedAt cursors (#24)

### DIFF
--- a/GeckoIssuesApp/ContentView.swift
+++ b/GeckoIssuesApp/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
                 .navigationTitle("Repositories")
         } content: {
             if appStore.selectedRepository != nil {
-                IssueListView(appStore: appStore, syncStore: syncStore, database: database)
+                IssueListView(appStore: appStore, authStore: authStore, syncStore: syncStore, database: database)
             } else {
                 ContentUnavailableView(
                     "Select a Repository",

--- a/GeckoIssuesApp/Services/GitHubSyncService.swift
+++ b/GeckoIssuesApp/Services/GitHubSyncService.swift
@@ -9,7 +9,7 @@ protocol SyncServiceProtocol: Sendable {
     func fetchViewerWithOrganizations(token: String) async throws -> GitHubSyncService.ViewerWithOrganizationsData
     func fetchRepositories(token: String) async throws -> [GitHubSyncService.RepositoryData]
     func fetchOrganizationRepositories(login: String, token: String) async throws -> [GitHubSyncService.RepositoryData]
-    func fetchIssues(owner: String, name: String, token: String) async throws -> [GitHubSyncService.IssueData]
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [GitHubSyncService.IssueData]
 }
 
 // MARK: - Service
@@ -106,10 +106,18 @@ struct GitHubSyncService: SyncServiceProtocol, Sendable {
 
     // MARK: - Fetch Issues
 
-    func fetchIssues(owner: String, name: String, token: String) async throws -> [IssueData] {
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [IssueData] {
+        let query = since != nil ? Queries.issuesIncremental : Queries.issues
+        var variables: [String: any Encodable & Sendable] = ["owner": owner, "name": name]
+        if let since {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            variables["since"] = formatter.string(from: since)
+        }
+
         let nodes: [IssueNode] = try await client.executePaginated(
-            query: Queries.issues,
-            variables: ["owner": owner, "name": name],
+            query: query,
+            variables: variables,
             token: token
         ) { (response: RepoIssuesResponse) in
             let conn = response.repository.issues
@@ -514,6 +522,57 @@ private enum Queries {
           after: $after,
           states: [OPEN, CLOSED],
           orderBy: { field: UPDATED_AT, direction: DESC }
+        ) {
+          nodes {
+            databaseId
+            number
+            title
+            body
+            state
+            url
+            createdAt
+            updatedAt
+            closedAt
+            author { login }
+            milestone {
+              id
+              number
+              title
+              description
+              state
+              dueOn
+            }
+            labels(first: 100) {
+              nodes { id name color description }
+            }
+            assignees(first: 100) {
+              nodes { databaseId login avatarUrl }
+            }
+            comments(first: 100) {
+              nodes {
+                id
+                author { login }
+                body
+                createdAt
+                updatedAt
+              }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    static let issuesIncremental = """
+    query($owner: String!, $name: String!, $since: DateTime!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        issues(
+          first: 50,
+          after: $after,
+          states: [OPEN, CLOSED],
+          orderBy: { field: UPDATED_AT, direction: DESC },
+          filterBy: { since: $since }
         ) {
           nodes {
             databaseId

--- a/GeckoIssuesApp/Services/PreviewSyncService.swift
+++ b/GeckoIssuesApp/Services/PreviewSyncService.swift
@@ -46,7 +46,7 @@ struct PreviewSyncService: SyncServiceProtocol {
         orgRepos[login] ?? personalRepos
     }
 
-    func fetchIssues(owner: String, name: String, token: String) async throws -> [GitHubSyncService.IssueData] {
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [GitHubSyncService.IssueData] {
         []
     }
 }

--- a/GeckoIssuesApp/Stores/SyncStore.swift
+++ b/GeckoIssuesApp/Stores/SyncStore.swift
@@ -64,9 +64,13 @@ final class SyncStore {
     /// Refresh all tracked repos by re-fetching their issues from GitHub.
     ///
     /// Reads the set of tracked repo IDs from the local database and only
-    /// fetches issues for those repos. Does not discover new repos — use
+    /// fetches issues for those repos. Uses incremental sync (fetching only
+    /// issues updated since the last sync) when a cursor exists. Pass
+    /// `force: true` to ignore stored cursors and do a full re-fetch.
+    ///
+    /// Does not discover new repos — use
     /// `startSyncForRepos(repoIds:token:)` for that.
-    func startFullSync(token: String) {
+    func startFullSync(token: String, force: Bool = false) {
         if case .syncing = state { return }
 
         errorMessage = nil
@@ -87,7 +91,7 @@ final class SyncStore {
                 logger.info("Starting refresh sync for \(trackedRepos.count) tracked repos")
 
                 let repoEntries = trackedRepos.map {
-                    (id: $0.id, nameWithOwner: $0.nameWithOwner)
+                    (id: $0.id, nameWithOwner: $0.nameWithOwner, syncedAt: force ? nil : $0.syncedAt)
                 }
                 try await syncIssues(for: repoEntries, token: token)
 
@@ -184,7 +188,7 @@ final class SyncStore {
                 // Step 4: Fetch and persist issues for selected repos only
                 let reposToSync = repos.filter { repoIds.contains($0.databaseId) }
                 let repoEntries = reposToSync.map {
-                    (id: $0.databaseId, nameWithOwner: $0.nameWithOwner)
+                    (id: $0.databaseId, nameWithOwner: $0.nameWithOwner, syncedAt: nil as Date?)
                 }
                 try await syncIssues(for: repoEntries, token: token)
 
@@ -217,8 +221,11 @@ final class SyncStore {
     // MARK: - Private Sync
 
     /// Fetch and persist issues for the given repos, updating sync progress.
+    ///
+    /// When `syncedAt` is non-nil for a repo, performs an incremental fetch
+    /// (only issues updated since that date). When nil, fetches all issues.
     private func syncIssues(
-        for repos: [(id: Int64, nameWithOwner: String)],
+        for repos: [(id: Int64, nameWithOwner: String, syncedAt: Date?)],
         token: String
     ) async throws {
         for (index, repo) in repos.enumerated() {
@@ -234,9 +241,16 @@ final class SyncStore {
             let owner = String(parts[0])
             let name = String(parts[1])
 
+            if repo.syncedAt != nil {
+                logger.info("Incremental sync for \(repo.nameWithOwner) (since \(repo.syncedAt!))")
+            } else {
+                logger.info("Full sync for \(repo.nameWithOwner)")
+            }
+
             let issues = try await syncService.fetchIssues(
                 owner: owner,
                 name: name,
+                since: repo.syncedAt,
                 token: token
             )
             logger.info("Fetched \(issues.count) issues for \(repo.nameWithOwner)")

--- a/GeckoIssuesApp/Views/IssueListView.swift
+++ b/GeckoIssuesApp/Views/IssueListView.swift
@@ -4,6 +4,7 @@ import GRDB
 /// Displays issues for the selected repository in a compact list with sorting controls.
 struct IssueListView: View {
     var appStore: AppStore
+    var authStore: AuthStore
     var syncStore: SyncStore
     var database: AppDatabase
 
@@ -28,6 +29,9 @@ struct IssueListView: View {
         }
         .toolbar {
             ToolbarItem(placement: .automatic) {
+                refreshButton
+            }
+            ToolbarItem(placement: .automatic) {
                 sortMenu
             }
         }
@@ -51,6 +55,29 @@ struct IssueListView: View {
         guard let repo = appStore.selectedRepository else { return "Issues" }
         let count = issues.count
         return "\(repo.name) — Issues (\(count))"
+    }
+
+    // MARK: - Refresh Button
+
+    private var refreshButton: some View {
+        Button {
+            guard let token = authStore.accessToken else { return }
+            syncStore.startFullSync(token: token)
+        } label: {
+            if case .syncing = syncStore.state {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                SwiftUI.Label("Refresh", systemImage: "arrow.clockwise")
+            }
+        }
+        .disabled(isSyncing)
+        .accessibilityLabel("Refresh issues")
+    }
+
+    private var isSyncing: Bool {
+        if case .syncing = syncStore.state { return true }
+        return false
     }
 
     // MARK: - Sort Menu

--- a/GeckoIssuesTests/SyncStoreTests.swift
+++ b/GeckoIssuesTests/SyncStoreTests.swift
@@ -28,8 +28,46 @@ struct MockSyncService: SyncServiceProtocol, Sendable {
         orgRepositories[login] ?? []
     }
 
-    func fetchIssues(owner: String, name: String, token: String) async throws -> [GitHubSyncService.IssueData] {
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [GitHubSyncService.IssueData] {
         issuesByRepo["\(owner)/\(name)"] ?? []
+    }
+}
+
+/// Mock that records `since` values passed to `fetchIssues` for verification.
+final class SpySyncService: SyncServiceProtocol, @unchecked Sendable {
+    let base: MockSyncService
+    private let lock = NSLock()
+    private var _sinceValues: [String: Date?] = [:]
+
+    var sinceValues: [String: Date?] {
+        lock.withLock { _sinceValues }
+    }
+
+    init(base: MockSyncService) {
+        self.base = base
+    }
+
+    func fetchViewer(token: String) async throws -> GitHubSyncService.ViewerData {
+        base.viewer
+    }
+
+    func fetchViewerWithOrganizations(token: String) async throws -> GitHubSyncService.ViewerWithOrganizationsData {
+        try await base.fetchViewerWithOrganizations(token: token)
+    }
+
+    func fetchRepositories(token: String) async throws -> [GitHubSyncService.RepositoryData] {
+        base.repositories
+    }
+
+    func fetchOrganizationRepositories(login: String, token: String) async throws -> [GitHubSyncService.RepositoryData] {
+        base.orgRepositories[login] ?? []
+    }
+
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [GitHubSyncService.IssueData] {
+        lock.withLock {
+            _sinceValues["\(owner)/\(name)"] = since
+        }
+        return base.issuesByRepo["\(owner)/\(name)"] ?? []
     }
 }
 
@@ -52,7 +90,7 @@ struct FailingSyncService: SyncServiceProtocol, Sendable {
         throw error
     }
 
-    func fetchIssues(owner: String, name: String, token: String) async throws -> [GitHubSyncService.IssueData] {
+    func fetchIssues(owner: String, name: String, since: Date?, token: String) async throws -> [GitHubSyncService.IssueData] {
         throw error
     }
 }
@@ -620,6 +658,130 @@ struct SyncStoreTests {
             try Repository.fetchAll(db)
         }
         #expect(repos.isEmpty)
+    }
+
+    @Test("Full sync passes syncedAt as since parameter for incremental fetch")
+    @MainActor
+    func fullSyncPassesSinceCursor() async throws {
+        let db = try AppDatabase.inMemory()
+        let owner = makeOwnerData()
+        let repo = makeRepoData(id: 100, name: "hello-world", owner: owner)
+        let issue = makeIssueData(id: 400, number: 1)
+
+        // First: discovery sync to populate the repo with a syncedAt timestamp
+        let discoveryMock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let store1 = SyncStore(database: db, syncService: discoveryMock)
+        store1.startSyncForRepos(repoIds: [100], token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store1.state { break }
+            if case .error(let msg) = store1.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Verify repo has syncedAt set
+        let repoAfterDiscovery = try await db.dbQueue.read { db in
+            try Repository.fetchOne(db, key: 100 as Int64)
+        }
+        #expect(repoAfterDiscovery?.syncedAt != nil)
+        let syncedAt = repoAfterDiscovery!.syncedAt!
+
+        // Second: full sync with spy to verify since is passed
+        let spyBase = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let spy = SpySyncService(base: spyBase)
+        let store2 = SyncStore(database: db, syncService: spy)
+        store2.startFullSync(token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store2.state { break }
+            if case .error(let msg) = store2.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Verify since was passed with the syncedAt value
+        let sinceValue = spy.sinceValues["octocat/hello-world"]
+        #expect(sinceValue != nil) // The key exists
+        #expect(sinceValue! != nil) // The Date? value is non-nil
+        // The since date should match the syncedAt from the first sync
+        let timeDifference = abs(sinceValue!!.timeIntervalSince(syncedAt))
+        #expect(timeDifference < 1.0) // Within 1 second
+    }
+
+    @Test("Discovery sync passes nil since (full fetch)")
+    @MainActor
+    func discoverySyncPassesNilSince() async throws {
+        let db = try AppDatabase.inMemory()
+        let repo = makeRepoData(id: 100, name: "hello-world")
+        let issue = makeIssueData(id: 400, number: 1)
+
+        let spyBase = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let spy = SpySyncService(base: spyBase)
+        let store = SyncStore(database: db, syncService: spy)
+        store.startSyncForRepos(repoIds: [100], token: "token")
+
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store.state { break }
+            if case .error(let msg) = store.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Discovery sync should always pass nil since (full fetch)
+        let sinceValue = spy.sinceValues["octocat/hello-world"]
+        #expect(sinceValue != nil) // The key exists
+        #expect(sinceValue! == nil) // The Date? value is nil (full fetch)
+    }
+
+    @Test("Force full sync ignores syncedAt cursor")
+    @MainActor
+    func forceSyncIgnoresCursor() async throws {
+        let db = try AppDatabase.inMemory()
+        let owner = makeOwnerData()
+        let repo = makeRepoData(id: 100, name: "hello-world", owner: owner)
+        let issue = makeIssueData(id: 400, number: 1)
+
+        // First: discovery sync to set syncedAt
+        let discoveryMock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let store1 = SyncStore(database: db, syncService: discoveryMock)
+        store1.startSyncForRepos(repoIds: [100], token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store1.state { break }
+            if case .error(let msg) = store1.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Second: force full sync — should pass nil since
+        let spyBase = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let spy = SpySyncService(base: spyBase)
+        let store2 = SyncStore(database: db, syncService: spy)
+        store2.startFullSync(token: "token", force: true)
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store2.state { break }
+            if case .error(let msg) = store2.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Force should ignore the cursor and pass nil
+        let sinceValue = spy.sinceValues["octocat/hello-world"]
+        #expect(sinceValue != nil) // The key exists
+        #expect(sinceValue! == nil) // The Date? value is nil (forced full fetch)
     }
 }
 


### PR DESCRIPTION
## Summary
- Use `Repository.syncedAt` as the incremental sync cursor — no schema changes needed
- Add `filterBy: {since: $since}` to the GitHub GraphQL issues query for repos that have been synced before
- First-time syncs and discovery syncs still perform a full fetch (since = nil)
- Add `force` parameter to `startFullSync()` to ignore stored cursors and do a complete re-fetch
- Add `SpySyncService` test helper and 3 new tests verifying incremental, discovery, and force sync behavior

Closes #24

## Acceptance Criteria
- [x] `SyncStore` stores the last-synced `updatedAt` timestamp per repo after each successful sync
- [x] Subsequent syncs pass `since: <timestamp>` (via GraphQL `filterBy`) to fetch only updated issues
- [x] Newly closed or reopened issues are reflected correctly (state changes are captured by `filterBy: {since:}`)
- [x] If no cursor exists (first sync for a repo), falls back to a full fetch
- [x] Cursors are stored in the local database and survive app restarts (uses existing `repositories.syncedAt`)
- [x] A forced full re-sync can be triggered manually (`startFullSync(token:, force: true)`)

## Test Plan
- [ ] Build succeeds (`xcodebuild build` ✅)
- [ ] Test target compiles (`build-for-testing` ✅)
- [ ] Run SyncStore tests — verify incremental sync passes `since` cursor
- [ ] Run SyncStore tests — verify discovery sync passes `nil` (full fetch)
- [ ] Run SyncStore tests — verify force sync ignores cursor
- [ ] Manual: Add a repo, sync, modify an issue on GitHub, sync again — confirm only the changed issue is fetched (check logs for "Incremental sync" message)
- [ ] Manual: Trigger force full sync — confirm all issues are re-fetched (check logs for "Full sync" message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)