### PR TITLE
Quit app when main window is closed (#30)

### DIFF
--- a/GeckoIssuesApp/GeckoIssuesApp.swift
+++ b/GeckoIssuesApp/GeckoIssuesApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct GeckoIssuesApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appStore = AppStore()
     @State private var navigationStore = NavigationStore()
     @State private var authStore = AuthStore()
@@ -33,5 +34,11 @@ struct GeckoIssuesApp: App {
                 database: database
             )
         }
+    }
+}
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
     }
 }


### PR DESCRIPTION
## Summary
- Adds an `AppDelegate` implementing `applicationShouldTerminateAfterLastWindowClosed` returning `true`, wired via `@NSApplicationDelegateAdaptor` in `GeckoIssuesApp`.
- Gecko Issues now quits when the main window is closed instead of lingering as a background process.

Closes #30

## Test plan
- [x] Launch the app, close the main window — app fully quits (no Dock icon, no background process).
- [x] Open Settings window, close it — app remains running (Settings is a separate scene, not the "last window").
- [x] Re-open from Dock / Launchpad after quit — cold-launches normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)