### PR TITLE
Online/offline detection (#27)

### DIFF
--- a/GeckoIssuesApp/ContentView.swift
+++ b/GeckoIssuesApp/ContentView.swift
@@ -42,6 +42,7 @@ struct ContentView: View {
             if !authStore.isAuthenticated {
                 navigationStore.activeSheet = .onboarding
             }
+            syncStore.startNetworkMonitoring()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             startBackgroundRefreshIfAuthenticated()

--- a/GeckoIssuesApp/Stores/SyncStore.swift
+++ b/GeckoIssuesApp/Stores/SyncStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import Network
 import os
 
 /// Manages GitHub sync lifecycle, background refresh, and online/offline state.
@@ -13,6 +14,7 @@ final class SyncStore {
         case syncing(SyncProgress)
         case completed(Date)
         case error(String)
+        case offline
     }
 
     struct SyncProgress: Equatable {
@@ -37,21 +39,29 @@ final class SyncStore {
 
     private let database: AppDatabase
     private let syncService: any SyncServiceProtocol
+    private let networkMonitor: any NetworkMonitorProtocol
     private let logger = Logger(subsystem: "com.32pixels.GeckoIssues", category: "SyncStore")
 
     // MARK: - Internal
 
+    private(set) var isOffline = false
     private var syncTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
+    private var networkTask: Task<Void, Never>?
+
+    /// Token stored for auto-reconnect sync after coming back online.
+    private var lastToken: String?
 
     // MARK: - Initialization
 
     init(
         database: AppDatabase,
-        syncService: any SyncServiceProtocol = GitHubSyncService()
+        syncService: any SyncServiceProtocol = GitHubSyncService(),
+        networkMonitor: any NetworkMonitorProtocol = NWPathMonitorWrapper()
     ) {
         self.database = database
         self.syncService = syncService
+        self.networkMonitor = networkMonitor
         restoreLastSyncDate()
     }
 
@@ -59,6 +69,7 @@ final class SyncStore {
     init(previewState: SyncState) {
         self.database = try! AppDatabase.inMemory()
         self.syncService = GitHubSyncService()
+        self.networkMonitor = NWPathMonitorWrapper()
         self.state = previewState
     }
 
@@ -85,7 +96,12 @@ final class SyncStore {
     /// `startSyncForRepos(repoIds:token:)` for that.
     func startFullSync(token: String, force: Bool = false) {
         if case .syncing = state { return }
+        if isOffline {
+            state = .offline
+            return
+        }
 
+        lastToken = token
         errorMessage = nil
         syncTask = Task {
             do {
@@ -146,7 +162,12 @@ final class SyncStore {
     /// repos via Settings.
     func startSyncForRepos(repoIds: Set<Int64>, token: String) {
         if case .syncing = state { return }
+        if isOffline {
+            state = .offline
+            return
+        }
 
+        lastToken = token
         errorMessage = nil
         syncTask = Task {
             do {
@@ -252,6 +273,7 @@ final class SyncStore {
     /// when the app resigns active.
     func startBackgroundRefresh(interval: TimeInterval, token: String) {
         stopBackgroundRefresh()
+        lastToken = token
         logger.info("Background refresh started (interval: \(interval)s)")
 
         refreshTask = Task {
@@ -273,6 +295,43 @@ final class SyncStore {
     func stopBackgroundRefresh() {
         refreshTask?.cancel()
         refreshTask = nil
+    }
+
+    // MARK: - Network Monitoring
+
+    /// Start observing network reachability. Transitions to `.offline` when
+    /// the network is unavailable and triggers an incremental sync when it
+    /// returns.
+    func startNetworkMonitoring() {
+        stopNetworkMonitoring()
+        networkTask = Task {
+            for await isConnected in networkMonitor.pathUpdates() {
+                if Task.isCancelled { break }
+                if isConnected {
+                    if isOffline {
+                        logger.info("Network restored — triggering sync")
+                        isOffline = false
+                        // Restore to last completed or idle state before auto-sync
+                        restoreLastSyncDate()
+                        if let token = lastToken {
+                            startFullSync(token: token)
+                        }
+                    }
+                } else {
+                    logger.info("Network lost — entering offline mode")
+                    isOffline = true
+                    cancelSync()
+                    stopBackgroundRefresh()
+                    state = .offline
+                }
+            }
+        }
+    }
+
+    /// Stop observing network reachability.
+    func stopNetworkMonitoring() {
+        networkTask?.cancel()
+        networkTask = nil
     }
 
     // MARK: - Private Sync
@@ -568,6 +627,32 @@ final class SyncStore {
         }
     }
 
+}
+
+// MARK: - Network Monitor Protocol
+
+/// Abstracts network reachability so tests can inject a mock.
+protocol NetworkMonitorProtocol: Sendable {
+    /// Returns an `AsyncStream` that emits `true` when the network is
+    /// reachable and `false` when it is not. The first value reflects the
+    /// current state at the time of subscription.
+    func pathUpdates() -> AsyncStream<Bool>
+}
+
+/// Production wrapper around `NWPathMonitor`.
+final class NWPathMonitorWrapper: NetworkMonitorProtocol, Sendable {
+    func pathUpdates() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            let monitor = NWPathMonitor()
+            monitor.pathUpdateHandler = { path in
+                continuation.yield(path.status == .satisfied)
+            }
+            continuation.onTermination = { _ in
+                monitor.cancel()
+            }
+            monitor.start(queue: DispatchQueue(label: "com.32pixels.GeckoIssues.networkMonitor"))
+        }
+    }
 }
 
 // MARK: - Date Parsing Helper

--- a/GeckoIssuesApp/Views/Components/SyncStatusBar.swift
+++ b/GeckoIssuesApp/Views/Components/SyncStatusBar.swift
@@ -53,6 +53,10 @@ struct SyncStatusBar: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 11))
                 .foregroundStyle(.red)
+        case .offline:
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -79,6 +83,10 @@ struct SyncStatusBar: View {
                 .foregroundStyle(.red)
                 .lineLimit(1)
                 .truncationMode(.tail)
+        case .offline:
+            Text("Offline")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -122,6 +130,8 @@ struct SyncStatusBar: View {
             }
             .controlSize(.small)
             .accessibilityLabel("Sync now")
+        case .offline:
+            EmptyView()
         }
     }
 }

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
@@ -186,7 +186,7 @@ struct AuthStepRow<Content: View>: View {
     @ViewBuilder var content: () -> Content
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
+        HStack(spacing: 14) {
             // Left column: indicator + connector line
             VStack(spacing: 0) {
                 indicator
@@ -199,8 +199,7 @@ struct AuthStepRow<Content: View>: View {
                         .padding(.vertical, 4)
                 }
             }
-            .frame(width: 24)
-            .frame(maxHeight: .infinity, alignment: .top)
+            .frame(width: 24, alignment: .top)
 
             // Right column: title + optional content
             VStack(alignment: .leading, spacing: 8) {

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
@@ -53,7 +53,7 @@ struct ConnectGitHubStepView: View {
                 }
             }
             .padding(.leading, 40)
-            .padding(.trailing, 32)
+            .padding(.trailing, 40)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
@@ -53,6 +53,7 @@ struct ConnectGitHubStepView: View {
                 }
             }
             .padding(.leading, 40)
+            .padding(.trailing, 32)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/ConnectGitHubStepView.swift
@@ -140,6 +140,7 @@ struct ConnectGitHubStepView: View {
                 Text(error)
                     .font(.system(size: 12))
                     .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
+++ b/GeckoIssuesApp/Views/Sheets/Onboarding/SyncingStepView.swift
@@ -106,6 +106,16 @@ struct SyncingStepView: View {
                 .controlSize(.large)
                 .accessibilityLabel("Retry sync")
             }
+
+        case .offline:
+            VStack(spacing: 12) {
+                Image(systemName: "wifi.slash")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.secondary)
+                Text("You appear to be offline. Sync will resume when the network is available.")
+                    .font(.system(size: 13))
+                    .multilineTextAlignment(.center)
+            }
         }
     }
 

--- a/GeckoIssuesTests/SyncStoreTests.swift
+++ b/GeckoIssuesTests/SyncStoreTests.swift
@@ -785,6 +785,156 @@ struct SyncStoreTests {
     }
 }
 
+// MARK: - Mock Network Monitor
+
+/// Test network monitor that lets tests control connectivity via continuations.
+final class MockNetworkMonitor: NetworkMonitorProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncStream<Bool>.Continuation?
+    private let initiallyConnected: Bool
+
+    init(connected: Bool = true) {
+        self.initiallyConnected = connected
+    }
+
+    func pathUpdates() -> AsyncStream<Bool> {
+        AsyncStream { continuation in
+            self.lock.withLock {
+                self.continuation = continuation
+            }
+            continuation.yield(self.initiallyConnected)
+        }
+    }
+
+    func setConnected(_ connected: Bool) {
+        lock.withLock {
+            continuation?.yield(connected)
+        }
+    }
+}
+
+// MARK: - Offline Detection Tests
+
+@Suite("SyncStore — Offline Detection")
+struct SyncStoreOfflineTests {
+
+    @Test("Offline network sets state to .offline")
+    @MainActor
+    func offlineNetworkSetsState() async throws {
+        let db = try AppDatabase.inMemory()
+        let mock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [],
+            issuesByRepo: [:]
+        )
+        let networkMonitor = MockNetworkMonitor(connected: false)
+        let store = SyncStore(database: db, syncService: mock, networkMonitor: networkMonitor)
+
+        store.startNetworkMonitoring()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(store.state == .offline)
+        #expect(store.isOffline == true)
+
+        store.stopNetworkMonitoring()
+    }
+
+    @Test("Sync attempt while offline fails fast with .offline state")
+    @MainActor
+    func syncWhileOfflineFailsFast() async throws {
+        let db = try AppDatabase.inMemory()
+        let mock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [],
+            issuesByRepo: [:]
+        )
+        let networkMonitor = MockNetworkMonitor(connected: false)
+        let store = SyncStore(database: db, syncService: mock, networkMonitor: networkMonitor)
+
+        store.startNetworkMonitoring()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Attempt sync while offline — should fail fast
+        store.startFullSync(token: "token")
+        #expect(store.state == .offline)
+
+        store.stopNetworkMonitoring()
+    }
+
+    @Test("Coming back online triggers sync automatically")
+    @MainActor
+    func comingOnlineTriggerSync() async throws {
+        let db = try AppDatabase.inMemory()
+        let owner = makeOwnerData()
+        let repo = makeRepoData(id: 100, name: "hello-world", owner: owner)
+        let issue = makeIssueData(id: 400, number: 1)
+
+        // First: discovery sync to set up tracked repos while online
+        let discoveryMock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [repo],
+            issuesByRepo: ["octocat/hello-world": [issue]]
+        )
+        let networkMonitor = MockNetworkMonitor(connected: true)
+        let store = SyncStore(database: db, syncService: discoveryMock, networkMonitor: networkMonitor)
+
+        store.startNetworkMonitoring()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Do a sync to store token and set up repos
+        store.startSyncForRepos(repoIds: [100], token: "token")
+        while true {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store.state { break }
+            if case .error(let msg) = store.state { throw SyncTestError.syncFailed(msg) }
+        }
+
+        // Go offline
+        networkMonitor.setConnected(false)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(store.state == .offline)
+
+        // Come back online — should auto-sync
+        networkMonitor.setConnected(true)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Wait for auto-sync to complete
+        for _ in 0..<40 {
+            try await Task.sleep(for: .milliseconds(50))
+            if case .completed = store.state { break }
+        }
+
+        if case .completed = store.state {
+            // Expected — auto-sync completed
+        } else {
+            #expect(Bool(false), "Expected .completed after reconnect, got \(store.state)")
+        }
+
+        store.stopNetworkMonitoring()
+    }
+
+    @Test("Discovery sync while offline fails fast")
+    @MainActor
+    func discoverySyncWhileOfflineFailsFast() async throws {
+        let db = try AppDatabase.inMemory()
+        let mock = MockSyncService(
+            viewer: makeViewerData(),
+            repositories: [],
+            issuesByRepo: [:]
+        )
+        let networkMonitor = MockNetworkMonitor(connected: false)
+        let store = SyncStore(database: db, syncService: mock, networkMonitor: networkMonitor)
+
+        store.startNetworkMonitoring()
+        try await Task.sleep(for: .milliseconds(100))
+
+        store.startSyncForRepos(repoIds: [100], token: "token")
+        #expect(store.state == .offline)
+
+        store.stopNetworkMonitoring()
+    }
+}
+
 // MARK: - Test Error
 
 private enum SyncTestError: Error {


### PR DESCRIPTION
## Summary
- Add `NWPathMonitor`-based network reachability monitoring to `SyncStore`
- Transition to `.offline` state when network is unavailable, pausing background refresh
- Fail fast on sync attempts while offline (no timeout wait)
- Auto-trigger incremental sync when network is restored
- Show offline state in `SyncStatusBar` (wifi.slash icon + "Offline" text) and onboarding wizard
- All local SQLite reads continue working while offline

Closes #27

## Acceptance Criteria
- [x] `SyncStore` monitors network reachability using `NWPathMonitor`
- [x] When the path becomes unsatisfied, `syncState` transitions to `.offline` and background refresh is paused
- [x] When the path becomes satisfied again, an incremental sync is triggered automatically
- [x] Sync attempts made while offline fail fast with an `.offline` error (no timeout wait)
- [x] All reads from the local SQLite store continue to work while offline
- [x] The sync status indicator reflects the offline state

## Test Plan
- [ ] Disconnect Wi-Fi — status bar shows wifi.slash icon and "Offline" text
- [ ] While offline, click any issue — detail view loads from local DB
- [ ] While offline, "Sync Now" button is hidden
- [ ] Reconnect Wi-Fi — sync triggers automatically and status returns to "Synced just now"
- [ ] Start onboarding while offline — shows offline message instead of progress
- [ ] Verify all 62 tests pass (including 4 new offline detection tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)